### PR TITLE
Enable CI for android and iOS

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,62 @@
+# This is a basic workflow to help you get started with Actions
+
+name: osx-ubuntu-build-android
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '* * * * 0'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Print the java version
+      run: java -version
+
+    - name: Tries to figure out where android is installed
+      run: |
+        echo "Android listed at $ANDROID_HOME"
+        ls -al /opt/
+
+    - name: Setup the cordova environment
+      shell: bash -l {0}
+      run: |
+        source setup/setup_android_native.sh
+        npx cordova -version
+        npx ionic -version
+
+    - name: Access cordova with a specified shell
+      shell: bash -l {0}
+      run: |
+        npx cordova -version
+        which gradle
+        gradle -version
+
+    - name: Build android
+      shell: bash -l {0}
+      run: |
+        echo $PATH
+        which gradle
+        gradle -version
+        echo "Let's rerun the sdkman again"
+        source ~/.sdkman/bin/sdkman-init.sh
+        echo $PATH
+        which gradle
+        gradle --version
+        npx cordova build android

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,62 @@
+# This is a basic workflow to help you get started with Actions
+
+name: osx-build-ios
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '* * * * 0'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Print the xcode path
+      run: xcode-select --print-path
+
+    - name: Print the xcode setup
+      run: xcodebuild -version -sdk
+
+    - name: Print applications through dmg
+      run: ls /Applications
+
+    - name: Print applications through brew
+      run: brew list
+
+    - name: Setup the cordova environment
+      shell: bash -l {0}
+      run: |
+        source setup/setup_ios_native.sh
+        npx cordova -version
+        npx ionic -version
+
+    - name: Access cordova directly
+      run: npx cordova -version
+
+    - name: Access cordova with a specified shell
+      shell: bash -l {0}
+      run: npx cordova -version
+
+    - name: Build ios
+      shell: bash -l {0}
+      run: npx cordova build ios
+
+    - name: Cleanup the cordova environment
+      shell: bash -l {0}
+      run: source setup/teardown_ios_native.sh
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Pre-requisites
     - to install a particular version, use [xcode-select](https://www.unix.com/man-page/OSX/1/xcode-select/)
     - or this [supposedly easier to use repo](https://github.com/xcpretty/xcode-install)
 - git
+- the most recent version of android studio
+
+Important
+---
+Most of the recent issues encountered have been due to incompatible setup. We
+have now:
+- locked down the dependencies,
+- created setup and teardown scripts to setup self-contained environments with
+  those dependencies, and
+- CI enabled to validate that they continue work.
+
+If you have setup failures, please compare the configuration in the passing CI
+builds with your configuration. That is almost certainly the source of the error.
 
 Installing
 ---

--- a/setup/setup_android_native.sh
+++ b/setup/setup_android_native.sh
@@ -1,0 +1,55 @@
+echo "Ensure we exit on error"
+set -e
+
+# we can build android on both ubuntu and OSX
+# should try both since there may be subtle differences
+PLATFORM=`uname -a`
+
+# both of these have java on Github Actions
+# but may not in docker, for example
+# should check for the existence of java and die if it doesn't exist
+echo "Checking for java in the path"
+JAVA_VERSION=`javac -version`
+echo "Found java in the path with version $JAVA_VERSION"
+
+echo "Setting up SDK environment"
+ANDROID_BUILD_TOOLS_VERSION=27.0.3
+MIN_SDK_VERSION=21
+TARGET_SDK_VERSION=28
+
+# Setup the development environment
+source setup/setup_shared.sh
+
+if [ -z $ANDROID_HOME ];
+then
+    echo "ANDROID_HOME not set, android SDK not found, exiting"
+    exit 1
+else
+    echo "ANDROID_HOME found at $ANDROID_HOME"
+fi
+
+echo "Setting up sdkman"
+curl -s "https://get.sdkman.io" | bash
+source ~/.sdkman/bin/sdkman-init.sh
+
+echo "Setting up gradle using SDKMan"
+sdk install gradle 4.1
+
+source setup/setup_shared_native.sh
+
+INSTALLED_COUNT=`npx cordova plugin list | wc -l`
+echo "Found $INSTALLED_COUNT plugins, expected 15"
+if [ $INSTALLED_COUNT -lt 15 ];
+then
+    echo "Found $INSTALLED_COUNT plugins, expected 15, retrying" 
+    sleep 5
+    npx cordova prepare
+elif [ $INSTALLED_COUNT -gt 15 ];
+then
+    echo "Found extra plugins!"
+    npx cordova plugin list
+    echo "Failing for investigation"
+    exit 1
+else
+    echo "All plugins installed successfully!"
+fi

--- a/setup/setup_ios_native.sh
+++ b/setup/setup_ios_native.sh
@@ -1,0 +1,31 @@
+# error out if any command fails
+set -e
+
+COCOAPODS_VERSION=1.9.1
+EXPECTED_PLUGIN_COUNT=15
+
+# Setup the development environment
+source setup/setup_shared.sh
+
+echo "Installing cocoapods"
+export PATH=~/.gem/ruby/2.6.0/bin:$PATH
+gem install --no-document --user-install cocoapods -v $COCOAPODS_VERSION
+
+source setup/setup_shared_native.sh
+
+INSTALLED_COUNT=`npx cordova plugin list | wc -l`
+echo "Found $INSTALLED_COUNT plugins, expected 15"
+if [ $INSTALLED_COUNT -lt 15 ];
+then
+    echo "Found $INSTALLED_COUNT plugins, expected 15, retrying" 
+    sleep 5
+    npx cordova prepare
+elif [ $INSTALLED_COUNT -gt 15 ];
+then
+    echo "Found extra plugins!"
+    npx cordova plugin list
+    echo "Failing for investigation"
+    exit 1
+else
+    echo "All plugins installed successfully!"
+fi

--- a/setup/setup_shared.sh
+++ b/setup/setup_shared.sh
@@ -1,0 +1,27 @@
+export NVM_VERSION=0.35.3
+export NODE_VERSION=13.12.0
+export NPM_VERSION=6.14.4
+
+echo "Is this in a CI environment? $CI"
+export CI="true"
+
+echo "Installing the correct version of nvm"
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh | bash
+
+echo "Setting up the variables to run nvm"
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+echo "Installing the correct node version"
+nvm install $NODE_VERSION
+
+echo "Check the version of npm"
+CURR_NPM_VERSION=`npm --version`
+if [ $CURR_NPM_VERSION != $NPM_VERSION ];
+then
+    echo "Invalid npm version, expected $NPM_VERSION, got $CURR_NPM_VERSION"
+    exit 1
+fi
+
+git remote add upstream https://github.com/covid19database/phone-app.git

--- a/setup/setup_shared_native.sh
+++ b/setup/setup_shared_native.sh
@@ -1,0 +1,20 @@
+./bin/configure_xml_and_json.js cordovabuild
+
+echo "Setting up all npm packages"
+npm install
+
+echo "Updating bower"
+npx bower update
+
+# By default, node doesn't fail if any of the steps fail. This makes it hard to
+# use in a CI environment, and leads to people reporting the node error rather
+# than the underlying error. One solution is to pass in a command line argument to node
+# to turn off that behavior. However, the cordova script automatically invokes node
+# and I don't see a .noderc to pass in the config option for all runs
+# So for now, I am going to hack this by adding the command line argument to
+# the cordova script. If anybody has a better option, they are welcome to share
+# it with us!
+echo "hack to make the local cordova fail on error"
+sed -i -e "s|/usr/bin/env node|/usr/bin/env node --unhandled-rejections=strict|" node_modules/cordova/bin/cordova
+
+npx cordova prepare

--- a/setup/teardown_ios_native.sh
+++ b/setup/teardown_ios_native.sh
@@ -1,0 +1,13 @@
+echo "Ensure we exit on error"
+set -e
+
+export COCOAPODS_VERSION=1.9.1
+source setup/teardown_shared.sh
+
+echo "Uninstalling cocoapods"
+gem uninstall cocoapods -v $COCOAPODS_VERSION
+
+echo "Removing all modules, plugins and platforms to make a fresh start"
+rm -rf node_modules
+rm -rf plugins
+rm -rf platforms

--- a/setup/teardown_shared.sh
+++ b/setup/teardown_shared.sh
@@ -1,0 +1,8 @@
+export COCOAPODS_VERSION=1.7.5
+export NODE_VERSION=9.4.0
+
+echo "Removing .nvm since we installed it"
+rm -rf ~/.nvm/$NODE_VERSION
+
+echo "Removing all the node modules"
+rm -rf ./node_modules


### PR DESCRIPTION
Essentially commit periodically until everything works
--------------------------
* Fix the sign_and_align_keys script

- Run cordova the new way
- label the resulting apk correctly

* Vastly simplify the instructions for installation

by reusing the setup script for the CI

* First version of the ios build

* Let's see whether the ios build works

* Actually switch to osx

* Fixed name + case on macos runner

* Switch back to ubuntu

To see if this is launched now

* Some more tries to get the ios build to work

* Add another test

To see if we can even launch two tests

* Rename the working CI and see if it still works

* Now change it to run on osx

* Now change the line from an echo to sth meaningful

* Now finally run sth related to xcode

* Finally run the setup script

+ remove the malformed workflows

* showbuildsettings only works in the ios directory

which we don't have yet

* Fix the xcodeselect + actually check in setup files

* Fix the setup script + actually add ios and android builds

* Fix infinite loop + remove android build

* Fix plugin check + cordova launch

* Specify a login shell

* Refactor the setup scripts to be common v/s native

* Upgrade cocoapods

This no longer requires `pod setup` so is much faster and takes much less room

* Let's also tear things down

* Add in the teardown scripts as well

* Don't have to remove cocoapods

+ minor fix to formatting

* Lets try the gem uninstall without the piped y

* Handle telemetry warnings better

* Fixing this forever?!

* Set the CI to true

woo! woo!

* Test out an initial android build

Including some sense of the build environments

* Run only on mac to avoid compile error

+ update README with android studio dependency

* Try this on ubuntu

* Try the android build

* Add the actual build steps to the android workflow

* Fix the ANDROID_HOME to use existing value

* Remove the sdkmanager configurations

since it looks like we can't modify them

```
setup/setup_android_native.sh: line 40: /usr/local/lib/android/sdk/tools/bin/sdkmanager: Permission denied
```

* More fixes

* Remove the sdkmanager call since it doesn't work

* Some more sdkman fixes

* Make the setup changes "stick"

* Last try to figure out how to use the proper gradle

* Get cordova to actually fail on error

+ minor refactoring of common code

* Upgrade node and npm versions

This allows us to use the  --unhandled-rejections CLI flag

* Fix the sed script to work on the real file

Instead of the symlinked location

* Fail only for android for now

* Let's put it back for iOS as well

The previous failure seemed to be transient

* More debugging for the gradle issue on android

* Run android on os only as well

Since:
- the ubuntu build appears to be flaky
- most app developers will build on mac in order to support ios as well