### PR TITLE
Set the scheduled check to run only once on the weekend

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,7 +11,7 @@ on:
     branches: [ master ]
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '* * * * 0'
+    - cron:  '5 4 * * 0'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -11,7 +11,7 @@ on:
     branches: [ master ]
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '* * * * 0'
+    - cron:  '5 4 * * 0'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ app-settings.json
 .idea/
 .io-config.json
 *.apk
+*.app.zip
 *.ipa
 www/js/control/collect-settings.js
 www/js/control/sync-settings.js


### PR DESCRIPTION
+ ignore `.app.zip` files since that is how we generate iOS deliverables